### PR TITLE
Add "OffGrid" mode to OPERATING_MODE_MAPPING for device 6422

### DIFF
--- a/custom_components/dessmonitor/device_support/devcode_6422.py
+++ b/custom_components/dessmonitor/device_support/devcode_6422.py
@@ -20,6 +20,7 @@ CHARGER_PRIORITY_MAPPING: dict[str, str] = {}
 
 OPERATING_MODE_MAPPING: dict[str, str] = {
     "Grid-Tie": "Grid Mode",
+    "OffGrid": "Off-Grid Mode",
 }
 
 SENSOR_TITLE_MAPPINGS: dict[str, str] = {


### PR DESCRIPTION
fix en error:
"ValueError: Sensor sensor.invertor_operating_mode provides state value 'OffGrid', which is not in the list of options provided"