### PR TITLE
Support end-user (SmartClient/SmartESS app) accounts

### DIFF
--- a/custom_components/dessmonitor/__init__.py
+++ b/custom_components/dessmonitor/__init__.py
@@ -18,18 +18,17 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import DessMonitorAPI, DessMonitorError
 from .const import (
-    CONF_ACCOUNT_MODE,
     CONF_CONNECTION_TYPE,
     CONF_LOCAL_MODE,
     CONF_UPDATE_INTERVAL,
     CONNECTION_TYPE_CLOUD,
     CONNECTION_TYPE_LOCAL,
-    DEFAULT_ACCOUNT_MODE,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LOCAL_MODE_DISABLED,
     LOCAL_MODE_PREFER_LOCAL,
     UNITS,
+    resolve_api_profile,
 )
 from .data_sources import snapshot_with_data_source
 from .device_support import (
@@ -114,7 +113,7 @@ def _create_api_client(hass: HomeAssistant, entry: ConfigEntry) -> DessMonitorAP
     company_key = entry.data.get("company_key", "bnrl_frRFjEz8Mkn")
     _LOGGER.debug("Initializing API client for user: %s", username)
 
-    account_mode = entry.data.get(CONF_ACCOUNT_MODE, DEFAULT_ACCOUNT_MODE)
+    api_profile = resolve_api_profile(entry.data)
 
     store: Store[dict[str, Any]] = Store(hass, 1, f"{DOMAIN}_{entry.entry_id}_auth")
 
@@ -123,7 +122,7 @@ def _create_api_client(hass: HomeAssistant, entry: ConfigEntry) -> DessMonitorAP
         password=entry.data["password"],
         company_key=company_key,
         store=store,
-        account_mode=account_mode,
+        api_profile=api_profile,
     )
 
 

--- a/custom_components/dessmonitor/__init__.py
+++ b/custom_components/dessmonitor/__init__.py
@@ -18,11 +18,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import DessMonitorAPI, DessMonitorError
 from .const import (
+    CONF_ACCOUNT_MODE,
     CONF_CONNECTION_TYPE,
     CONF_LOCAL_MODE,
     CONF_UPDATE_INTERVAL,
     CONNECTION_TYPE_CLOUD,
     CONNECTION_TYPE_LOCAL,
+    DEFAULT_ACCOUNT_MODE,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LOCAL_MODE_DISABLED,
@@ -112,6 +114,8 @@ def _create_api_client(hass: HomeAssistant, entry: ConfigEntry) -> DessMonitorAP
     company_key = entry.data.get("company_key", "bnrl_frRFjEz8Mkn")
     _LOGGER.debug("Initializing API client for user: %s", username)
 
+    account_mode = entry.data.get(CONF_ACCOUNT_MODE, DEFAULT_ACCOUNT_MODE)
+
     store: Store[dict[str, Any]] = Store(hass, 1, f"{DOMAIN}_{entry.entry_id}_auth")
 
     return DessMonitorAPI(
@@ -119,6 +123,7 @@ def _create_api_client(hass: HomeAssistant, entry: ConfigEntry) -> DessMonitorAP
         password=entry.data["password"],
         company_key=company_key,
         store=store,
+        account_mode=account_mode,
     )
 
 

--- a/custom_components/dessmonitor/api.py
+++ b/custom_components/dessmonitor/api.py
@@ -12,7 +12,13 @@ import aiohttp
 import async_timeout
 from homeassistant.helpers.storage import Store
 
-from .const import API_BASE_URL, UNITS, VERSION
+from .const import (
+    ACCOUNT_PROFILES,
+    API_BASE_URL,
+    DEFAULT_ACCOUNT_MODE,
+    UNITS,
+    VERSION,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,12 +43,24 @@ class DessMonitorAPI:
         company_key: str = "bnrl_frRFjEz8Mkn",
         session: aiohttp.ClientSession | None = None,
         store: Store | None = None,
+        account_mode: str = DEFAULT_ACCOUNT_MODE,
     ) -> None:
         """Initialize the API client."""
         self.username = username
         self.password = password
         self.company_key = company_key
-        self.base_url = API_BASE_URL
+
+        # Resolve the per-account-mode API profile. Host, auth action, source
+        # and app identity all come from here so a session stays consistent.
+        profile = ACCOUNT_PROFILES.get(
+            account_mode, ACCOUNT_PROFILES[DEFAULT_ACCOUNT_MODE]
+        )
+        self.account_mode = account_mode
+        self.base_url = profile["base_url"]
+        self._auth_action = profile["auth_action"]
+        self._source = profile["source"]
+        self._app_client = profile["app_client"]
+        self._app_id = profile["app_id"]
 
         self._session = session
         self._close_session = False
@@ -115,7 +133,7 @@ class DessMonitorAPI:
 
     async def _ensure_token(self, action: str) -> None:
         """Refresh authentication token when required."""
-        if action == "authSource":
+        if action == self._auth_action:
             return
         if self._is_token_expired():
             _LOGGER.info("Token expired for action '%s', re-authenticating...", action)
@@ -134,7 +152,7 @@ class DessMonitorAPI:
     ) -> str:
         """Construct the full request URL including token when available."""
         url = f"{self.base_url}?sign={signature}&salt={salt}"
-        if self.token and action != "authSource":
+        if self.token and action != self._auth_action:
             url += f"&token={self.token}"
         return f"{url}{action_string}"
 
@@ -209,9 +227,9 @@ class DessMonitorAPI:
             auth_params = {
                 "usr": self.username,
                 "company-key": self.company_key,
-                "source": "1",
-                "_app_client_": "web",
-                "_app_id_": "ha-dessmonitor",
+                "source": self._source,
+                "_app_client_": self._app_client,
+                "_app_id_": self._app_id,
                 "_app_version_": VERSION,
             }
             _LOGGER.debug(
@@ -226,7 +244,7 @@ class DessMonitorAPI:
                 },
             )
 
-            response = await self._make_request("authSource", auth_params)
+            response = await self._make_request(self._auth_action, auth_params)
 
             if "dat" in response:
                 data = response["dat"]
@@ -614,7 +632,7 @@ class DessMonitorAPI:
             "queryDeviceCtrlField",
             {
                 "i18n": "en_US",
-                "source": "1",
+                "source": self._source,
                 "pn": pn,
                 "devcode": devcode,
                 "devaddr": devaddr,
@@ -668,7 +686,7 @@ class DessMonitorAPI:
             "queryDeviceParsEs",
             {
                 "i18n": "en_US",
-                "source": "1",
+                "source": self._source,
                 "pn": pn,
                 "devcode": devcode,
                 "devaddr": devaddr,
@@ -714,7 +732,7 @@ class DessMonitorAPI:
                 "sn": sn,
                 "id": field_id,
                 "i18n": "en_US",
-                "source": "1",
+                "source": self._source,
             },
         )
         return response.get("dat", {})
@@ -744,7 +762,7 @@ class DessMonitorAPI:
             "id": param_id,
             "val": value,
             "i18n": "en_US",
-            "source": "1",
+            "source": self._source,
         }
 
         return await self._make_request("ctrlDevice", params)

--- a/custom_components/dessmonitor/api.py
+++ b/custom_components/dessmonitor/api.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import time
 from typing import Any
+from urllib.parse import quote_plus
 
 import aiohttp
 import async_timeout
@@ -47,7 +48,7 @@ class DessMonitorAPI:
     ) -> None:
         """Initialize the API client."""
         self.username = username
-        self.password = password
+        self.password = password.strip() if password else password
         self.company_key = company_key
 
         # Resolve the per-account-mode API profile. Host, auth action, source
@@ -140,11 +141,20 @@ class DessMonitorAPI:
             await self.authenticate()
 
     def _build_action_string(self, action: str, params: dict[str, Any] | None) -> str:
-        """Construct action string used by the API."""
+        """Construct action string used by the API.
+
+        Values are percent-encoded with quote_plus so that the string used to
+        compute the signature is byte-for-byte what the HTTP client transmits.
+        aiohttp/yarl turn a space into "+" and preserve "+"/%XX, so signing the
+        raw value while sending the encoded one makes the server recompute a
+        different signature and reject it as ERR_PASSWORD_VERIF_FAIL. This bites
+        any account whose username or parameters contain a space or reserved
+        character.
+        """
         action_string = f"&action={action}"
         if params:
             for key, value in params.items():
-                action_string += f"&{key}={value}"
+                action_string += f"&{key}={quote_plus(str(value))}"
         return action_string
 
     def _build_request_url(
@@ -215,8 +225,9 @@ class DessMonitorAPI:
     async def authenticate(self) -> bool:
         """Authenticate with the DessMonitor API."""
         _LOGGER.debug(
-            "Starting authentication process for user: %s",
+            "Starting authentication process for user: %s (account_mode=%s)",
             _mask_identifier(self.username),
+            self.account_mode,
         )
         try:
             self.token = None

--- a/custom_components/dessmonitor/api.py
+++ b/custom_components/dessmonitor/api.py
@@ -11,12 +11,12 @@ from urllib.parse import quote_plus
 
 import aiohttp
 import async_timeout
+import yarl
 from homeassistant.helpers.storage import Store
 
 from .const import (
-    ACCOUNT_PROFILES,
-    API_BASE_URL,
-    DEFAULT_ACCOUNT_MODE,
+    API_PROFILES,
+    DEFAULT_API_PROFILE,
     UNITS,
     VERSION,
 )
@@ -44,19 +44,17 @@ class DessMonitorAPI:
         company_key: str = "bnrl_frRFjEz8Mkn",
         session: aiohttp.ClientSession | None = None,
         store: Store | None = None,
-        account_mode: str = DEFAULT_ACCOUNT_MODE,
+        api_profile: str = DEFAULT_API_PROFILE,
     ) -> None:
         """Initialize the API client."""
         self.username = username
-        self.password = password.strip() if password else password
+        self.password = password
         self.company_key = company_key
 
-        # Resolve the per-account-mode API profile. Host, auth action, source
+        # Resolve the API profile. Host, auth action, source
         # and app identity all come from here so a session stays consistent.
-        profile = ACCOUNT_PROFILES.get(
-            account_mode, ACCOUNT_PROFILES[DEFAULT_ACCOUNT_MODE]
-        )
-        self.account_mode = account_mode
+        profile = API_PROFILES.get(api_profile, API_PROFILES[DEFAULT_API_PROFILE])
+        self.api_profile = api_profile
         self.base_url = profile["base_url"]
         self._auth_action = profile["auth_action"]
         self._source = profile["source"]
@@ -145,11 +143,15 @@ class DessMonitorAPI:
 
         Values are percent-encoded with quote_plus so that the string used to
         compute the signature is byte-for-byte what the HTTP client transmits.
-        aiohttp/yarl turn a space into "+" and preserve "+"/%XX, so signing the
-        raw value while sending the encoded one makes the server recompute a
-        different signature and reject it as ERR_PASSWORD_VERIF_FAIL. This bites
-        any account whose username or parameters contain a space or reserved
-        character.
+        Signing the raw value while sending the encoded one makes the server
+        recompute a different signature and reject it as
+        ERR_PASSWORD_VERIF_FAIL. This bites any account whose username or
+        parameters contain a space or a reserved character.
+
+        Encoding here is only half the fix: yarl re-quotes a URL string it is
+        given, and its rules differ from quote_plus on "/" and "?" -- it turns
+        %2F and %3F back into the bare characters. So the URL must also be
+        handed to aiohttp as an already-encoded yarl.URL; see _fetch_json.
         """
         action_string = f"&action={action}"
         if params:
@@ -173,7 +175,7 @@ class DessMonitorAPI:
 
         try:
             async with async_timeout.timeout(timeout_seconds):
-                async with self._session.get(url) as response:
+                async with self._session.get(yarl.URL(url, encoded=True)) as response:
                     response.raise_for_status()
                     try:
                         return await response.json()
@@ -225,9 +227,9 @@ class DessMonitorAPI:
     async def authenticate(self) -> bool:
         """Authenticate with the DessMonitor API."""
         _LOGGER.debug(
-            "Starting authentication process for user: %s (account_mode=%s)",
+            "Starting authentication process for user: %s (api_profile=%s)",
             _mask_identifier(self.username),
-            self.account_mode,
+            self.api_profile,
         )
         try:
             self.token = None
@@ -317,6 +319,22 @@ class DessMonitorAPI:
         if not data:
             return False
 
+        # A token is only valid on the host that issued it. An entry whose
+        # profile changed would otherwise replay a dessmonitor.com token
+        # against ios.shinemonitor.com, which fails in a way that looks like
+        # bad credentials. Tokens cached before this field existed have no
+        # profile recorded, so they are treated as belonging to the default.
+        saved_profile = data.get("api_profile", DEFAULT_API_PROFILE)
+        if saved_profile != self.api_profile:
+            _LOGGER.debug(
+                "Cached token belongs to profile '%s' but this entry uses "
+                "'%s', discarding it",
+                saved_profile,
+                self.api_profile,
+            )
+            await self.clear_saved_token()
+            return False
+
         saved_token = data.get("token")
         saved_secret = data.get("secret")
         saved_expire = data.get("token_expire")
@@ -354,6 +372,7 @@ class DessMonitorAPI:
                     "token": self.token,
                     "secret": self.secret,
                     "token_expire": self.token_expire,
+                    "api_profile": self.api_profile,
                 }
             )
             _LOGGER.debug("Token saved to storage")

--- a/custom_components/dessmonitor/config_flow.py
+++ b/custom_components/dessmonitor/config_flow.py
@@ -21,6 +21,8 @@ from homeassistant.helpers.selector import (
 
 from .api import DessMonitorAPI, DessMonitorError
 from .const import (
+    ACCOUNT_MODE_OPTIONS,
+    CONF_ACCOUNT_MODE,
     CONF_COMPANY_KEY,
     CONF_CONNECTION_TYPE,
     CONF_LOCAL_COLLECTOR_IP,
@@ -39,6 +41,7 @@ from .const import (
     CONNECTION_TYPE_CLOUD,
     CONNECTION_TYPE_HYBRID,
     CONNECTION_TYPE_LOCAL,
+    DEFAULT_ACCOUNT_MODE,
     DEFAULT_COMPANY_KEY,
     DEFAULT_LOCAL_DEVICE_CODE,
     DEFAULT_LOCAL_POLL_INTERVAL,
@@ -88,6 +91,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_COMPANY_KEY, default=DEFAULT_COMPANY_KEY): vol.All(
             str, vol.Length(min=1, max=100)
         ),
+        vol.Optional(
+            CONF_ACCOUNT_MODE, default=DEFAULT_ACCOUNT_MODE
+        ): vol.In(ACCOUNT_MODE_OPTIONS),
         vol.Optional(
             CONF_UPDATE_INTERVAL, default=str(DEFAULT_UPDATE_INTERVAL)
         ): _list_choice(UPDATE_INTERVAL_OPTIONS),
@@ -350,11 +356,14 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     )
 
     session = async_get_clientsession(hass)
+    account_mode = data.get(CONF_ACCOUNT_MODE, DEFAULT_ACCOUNT_MODE)
+
     api = DessMonitorAPI(
         username=username,
         password=data[CONF_PASSWORD],
         company_key=company_key,
         session=session,
+        account_mode=account_mode,
     )
 
     try:

--- a/custom_components/dessmonitor/config_flow.py
+++ b/custom_components/dessmonitor/config_flow.py
@@ -21,8 +21,8 @@ from homeassistant.helpers.selector import (
 
 from .api import DessMonitorAPI, DessMonitorError
 from .const import (
-    ACCOUNT_MODE_OPTIONS,
-    CONF_ACCOUNT_MODE,
+    API_PROFILE_OPTIONS,
+    CONF_API_PROFILE,
     CONF_COMPANY_KEY,
     CONF_CONNECTION_TYPE,
     CONF_LOCAL_COLLECTOR_IP,
@@ -41,7 +41,7 @@ from .const import (
     CONNECTION_TYPE_CLOUD,
     CONNECTION_TYPE_HYBRID,
     CONNECTION_TYPE_LOCAL,
-    DEFAULT_ACCOUNT_MODE,
+    DEFAULT_API_PROFILE,
     DEFAULT_COMPANY_KEY,
     DEFAULT_LOCAL_DEVICE_CODE,
     DEFAULT_LOCAL_POLL_INTERVAL,
@@ -54,6 +54,7 @@ from .const import (
     LOCAL_MODE_PREFER_LOCAL,
     LOCAL_POLL_INTERVAL_OPTIONS,
     UPDATE_INTERVAL_OPTIONS,
+    resolve_api_profile,
 )
 from .local.network import normalize_local_ipv4
 
@@ -84,6 +85,19 @@ def _list_choice(choices: dict[int, str]) -> vol.All:
     )
 
 
+def _cloud_unique_id(username: str, data: dict[str, Any]) -> str:
+    """Unique ID for a cloud account, namespaced by API profile.
+
+    The same username can exist on both platforms as different accounts, so the
+    profile has to be part of the identity. The default profile keeps the bare
+    username so that entries created before this existed are not orphaned.
+    """
+    profile = resolve_api_profile(data)
+    if profile == DEFAULT_API_PROFILE:
+        return username
+    return f"{profile}:{username}"
+
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): vol.All(str, vol.Length(min=1, max=100)),
@@ -91,9 +105,9 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_COMPANY_KEY, default=DEFAULT_COMPANY_KEY): vol.All(
             str, vol.Length(min=1, max=100)
         ),
-        vol.Optional(
-            CONF_ACCOUNT_MODE, default=DEFAULT_ACCOUNT_MODE
-        ): vol.In(ACCOUNT_MODE_OPTIONS),
+        vol.Optional(CONF_API_PROFILE, default=DEFAULT_API_PROFILE): _list_choice(
+            API_PROFILE_OPTIONS
+        ),
         vol.Optional(
             CONF_UPDATE_INTERVAL, default=str(DEFAULT_UPDATE_INTERVAL)
         ): _list_choice(UPDATE_INTERVAL_OPTIONS),
@@ -356,14 +370,14 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     )
 
     session = async_get_clientsession(hass)
-    account_mode = data.get(CONF_ACCOUNT_MODE, DEFAULT_ACCOUNT_MODE)
+    api_profile = resolve_api_profile(data)
 
     api = DessMonitorAPI(
         username=username,
         password=data[CONF_PASSWORD],
         company_key=company_key,
         session=session,
-        account_mode=account_mode,
+        api_profile=api_profile,
     )
 
     try:
@@ -451,7 +465,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                 )
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(username)
+                await self.async_set_unique_id(_cloud_unique_id(username, user_input))
                 self._abort_if_unique_id_configured()
                 self._pending_hybrid_cloud_data = {
                     **user_input,
@@ -541,7 +555,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
                     "Setting unique ID and creating config entry for: %s",
                     _mask_username(username),
                 )
-                await self.async_set_unique_id(username)
+                await self.async_set_unique_id(_cloud_unique_id(username, user_input))
                 self._abort_if_unique_id_configured()
 
                 _LOGGER.info(

--- a/custom_components/dessmonitor/const.py
+++ b/custom_components/dessmonitor/const.py
@@ -57,6 +57,49 @@ UPDATE_INTERVAL_OPTIONS: Final = {
 
 API_BASE_URL: Final = "https://api.dessmonitor.com/public/"
 
+
+# --- Account mode -----------------------------------------------------------
+# Eybond's backend serves two different kinds of account, and they are NOT
+# interchangeable: the request host, the auth action and the app identity all
+# differ. Picking the wrong one returns ERR_NOT_FOUND_USR as if the account did
+# not exist.
+#
+#   * "distributor" - installer / distributor accounts, authenticated with
+#     action=authSource against api.dessmonitor.com. This is the original
+#     behaviour and stays the default.
+#   * "end_user" - accounts created in the SmartClient / SmartESS mobile apps,
+#     authenticated with action=auth against ios.shinemonitor.com, using the
+#     mobile app identity. Confirmed by capturing the SmartClient app's own
+#     traffic (action=auth, _app_id_=com.eybond.SmartClient, source=0).
+CONF_ACCOUNT_MODE: Final = "account_mode"
+ACCOUNT_MODE_DISTRIBUTOR: Final = "distributor"
+ACCOUNT_MODE_END_USER: Final = "end_user"
+DEFAULT_ACCOUNT_MODE: Final = ACCOUNT_MODE_DISTRIBUTOR
+
+ACCOUNT_MODE_OPTIONS: Final = {
+    ACCOUNT_MODE_DISTRIBUTOR: "Distributor / installer account",
+    ACCOUNT_MODE_END_USER: "End-user account (SmartClient / SmartESS app)",
+}
+
+# Per-mode API profile. Every request (auth and queries) uses these values, so
+# that host, source and identity stay consistent within a session.
+ACCOUNT_PROFILES: Final = {
+    ACCOUNT_MODE_DISTRIBUTOR: {
+        "base_url": "https://api.dessmonitor.com/public/",
+        "auth_action": "authSource",
+        "source": "1",
+        "app_client": "web",
+        "app_id": "ha-dessmonitor",
+    },
+    ACCOUNT_MODE_END_USER: {
+        "base_url": "https://ios.shinemonitor.com/public/",
+        "auth_action": "auth",
+        "source": "0",
+        "app_client": "ios",
+        "app_id": "com.eybond.SmartClient",
+    },
+}
+
 UNITS: Final = {
     "POWER": "W",
     "POWER_KW": "kW",

--- a/custom_components/dessmonitor/const.py
+++ b/custom_components/dessmonitor/const.py
@@ -58,47 +58,76 @@ UPDATE_INTERVAL_OPTIONS: Final = {
 API_BASE_URL: Final = "https://api.dessmonitor.com/public/"
 
 
-# --- Account mode -----------------------------------------------------------
-# Eybond's backend serves two different kinds of account, and they are NOT
-# interchangeable: the request host, the auth action and the app identity all
-# differ. Picking the wrong one returns ERR_NOT_FOUND_USR as if the account did
-# not exist.
+# --- API profile -------------------------------------------------------------
+# Eybond's backend serves two application profiles, and they are NOT
+# interchangeable: the request host, the auth action and `source` all differ.
+# Picking the wrong one returns ERR_NOT_FOUND_USR as if the account did not
+# exist.
 #
-#   * "distributor" - installer / distributor accounts, authenticated with
-#     action=authSource against api.dessmonitor.com. This is the original
-#     behaviour and stays the default.
-#   * "end_user" - accounts created in the SmartClient / SmartESS mobile apps,
-#     authenticated with action=auth against ios.shinemonitor.com, using the
-#     mobile app identity. Confirmed by capturing the SmartClient app's own
-#     traffic (action=auth, _app_id_=com.eybond.SmartClient, source=0).
-CONF_ACCOUNT_MODE: Final = "account_mode"
-ACCOUNT_MODE_DISTRIBUTOR: Final = "distributor"
-ACCOUNT_MODE_END_USER: Final = "end_user"
-DEFAULT_ACCOUNT_MODE: Final = ACCOUNT_MODE_DISTRIBUTOR
+# The axis is the platform, not the kind of account. The ShineMonitor
+# documentation defines source=0 as photovoltaic and source=1 as energy storage:
+#
+#   * "dessmonitor_ess" - energy storage, action=authSource against
+#     api.dessmonitor.com. Original behaviour, and the default.
+#   * "shinemonitor_solar" - photovoltaic, action=auth against
+#     ios.shinemonitor.com. Verified against a live grid-tie PV account
+#     (devcode 518).
+CONF_API_PROFILE: Final = "api_profile"
+API_PROFILE_DESSMONITOR_ESS: Final = "dessmonitor_ess"
+API_PROFILE_SHINEMONITOR_SOLAR: Final = "shinemonitor_solar"
+DEFAULT_API_PROFILE: Final = API_PROFILE_DESSMONITOR_ESS
 
-ACCOUNT_MODE_OPTIONS: Final = {
-    ACCOUNT_MODE_DISTRIBUTOR: "Distributor / installer account",
-    ACCOUNT_MODE_END_USER: "End-user account (SmartClient / SmartESS app)",
+# Key used by an earlier revision of this branch, never released. Only branch
+# testers have entries carrying it; mapping it keeps them working instead of
+# silently falling back to the default profile. Safe to drop before merge.
+LEGACY_CONF_ACCOUNT_MODE: Final = "account_mode"
+LEGACY_ACCOUNT_MODE_MAP: Final = {
+    "distributor": API_PROFILE_DESSMONITOR_ESS,
+    "end_user": API_PROFILE_SHINEMONITOR_SOLAR,
 }
 
-# Per-mode API profile. Every request (auth and queries) uses these values, so
-# that host, source and identity stay consistent within a session.
-ACCOUNT_PROFILES: Final = {
-    ACCOUNT_MODE_DISTRIBUTOR: {
+API_PROFILE_OPTIONS: Final = {
+    API_PROFILE_DESSMONITOR_ESS: "DessMonitor / SmartESS (energy storage)",
+    API_PROFILE_SHINEMONITOR_SOLAR: (
+        "ShineMonitor / SmartClient for Solar (photovoltaic)"
+    ),
+}
+
+# Per-profile request context. Host, auth action and `source` stay consistent
+# across every request in a session.
+#
+# The integration identifies itself as itself in both profiles. An earlier
+# revision of this branch sent `_app_id_=com.eybond.SmartClient` on the solar
+# profile, copied from a capture of the mobile app. Testing against a live
+# account shows the server does not require it: `action=auth&source=0` succeeds
+# with `_app_id_=ha-dessmonitor`, and also with no app context at all. So there
+# is no reason to impersonate someone else's application.
+API_PROFILES: Final = {
+    API_PROFILE_DESSMONITOR_ESS: {
         "base_url": "https://api.dessmonitor.com/public/",
         "auth_action": "authSource",
         "source": "1",
         "app_client": "web",
         "app_id": "ha-dessmonitor",
     },
-    ACCOUNT_MODE_END_USER: {
+    API_PROFILE_SHINEMONITOR_SOLAR: {
         "base_url": "https://ios.shinemonitor.com/public/",
         "auth_action": "auth",
         "source": "0",
-        "app_client": "ios",
-        "app_id": "com.eybond.SmartClient",
+        "app_client": "web",
+        "app_id": "ha-dessmonitor",
     },
 }
+
+
+def resolve_api_profile(data: dict) -> str:
+    """Return the API profile for a config entry, accepting the legacy key."""
+    profile = data.get(CONF_API_PROFILE)
+    if profile in API_PROFILES:
+        return profile
+    legacy = data.get(LEGACY_CONF_ACCOUNT_MODE)
+    return LEGACY_ACCOUNT_MODE_MAP.get(legacy, DEFAULT_API_PROFILE)
+
 
 UNITS: Final = {
     "POWER": "W",

--- a/custom_components/dessmonitor/device_support/devcode_518.py
+++ b/custom_components/dessmonitor/device_support/devcode_518.py
@@ -1,7 +1,8 @@
 """Solar grid-tie inverter (devcode 518).
 
-Single-/three-phase string inverter reported by SmartClient/SmartESS accounts
-(e.g. Q0025-series data loggers). queryDeviceLastData returns lower-cased,
+Single-/three-phase string inverter reported on the ShineMonitor solar
+platform (e.g. Q0025-series data loggers). Verified with a SmartClient for
+Solar account; not verified on SmartESS. queryDeviceLastData returns lower-cased,
 spelled-out field titles ("active power", "total energy", "today energy") that
 do not match the integration's canonical sensor names, so without this mapping
 the energy and power sensors stay at 0 even though the data is present.

--- a/custom_components/dessmonitor/device_support/devcode_518.py
+++ b/custom_components/dessmonitor/device_support/devcode_518.py
@@ -1,0 +1,45 @@
+"""Solar grid-tie inverter (devcode 518).
+
+Single-/three-phase string inverter reported by SmartClient/SmartESS accounts
+(e.g. Q0025-series data loggers). queryDeviceLastData returns lower-cased,
+spelled-out field titles ("active power", "total energy", "today energy") that
+do not match the integration's canonical sensor names, so without this mapping
+the energy and power sensors stay at 0 even though the data is present.
+
+Field titles captured from a live devcode 518 inverter (BRAZIL-H grid profile).
+"""
+
+from __future__ import annotations
+
+DEVICE_INFO = {
+    "name": "Solar Grid-Tie Inverter (devcode 518)",
+    "description": "String PV grid-tie inverter",
+    "manufacturer": "Eybond",
+    "known_inverters": ["Q0025-series"],
+    "supported_features": [
+        "real_time_monitoring",
+        "energy_tracking",
+        "solar_tracking",
+    ],
+}
+
+# Raw API title -> canonical name present in const.SENSOR_TYPES.
+SENSOR_TITLE_MAPPINGS = {
+    "active power": "Output Active Power",
+    "DC output power": "PV Power",
+    "total energy": "Energy Total",
+    "today energy": "Energy Today",
+    "current year generating capacity": "Energy Year",
+    "grid frequency": "Grid Frequency",
+    "inverter temperature": "INV Module Termperature",
+    "DC voltage 1": "PV1 Voltage",
+    "DC current 1": "PV1 Charger Current",
+    "DC voltage 2": "PV2 Voltage",
+    "DC current 2": "PV2 Charger Current",
+    "apparent power value": "Output Apparent Power",
+}
+
+DEVCODE_CONFIG = {
+    "device_info": DEVICE_INFO,
+    "sensor_title_mappings": SENSOR_TITLE_MAPPINGS,
+}

--- a/custom_components/dessmonitor/device_support/device_registry.py
+++ b/custom_components/dessmonitor/device_support/device_registry.py
@@ -72,6 +72,10 @@ def _load_device_configurations() -> None:
 
         _register_devcode(2507, config_2507)
 
+        from .devcode_518 import DEVCODE_CONFIG as config_518
+
+        _register_devcode(518, config_518)
+
     except ImportError as err:
         _LOGGER.error("Failed to import device configuration: %s", err)
 

--- a/custom_components/dessmonitor/strings.json
+++ b/custom_components/dessmonitor/strings.json
@@ -34,13 +34,15 @@
           "username": "Username",
           "password": "Password",
           "company_key": "Company Key (leave default unless specified by your installer)",
-          "update_interval": "Update interval (seconds)"
+          "update_interval": "Update interval (seconds)",
+          "account_mode": "Account type"
         },
         "data_description": {
           "username": "Your DessMonitor account username",
           "password": "Your DessMonitor account password",
           "company_key": "Your company/vendor key (default: {default_company_key})",
-          "update_interval": "How often to fetch data from DessMonitor. Default is 300 seconds (5 minutes)."
+          "update_interval": "How often to fetch data from DessMonitor. Default is 300 seconds (5 minutes).",
+          "account_mode": "Distributor/installer accounts use authSource against api.dessmonitor.com (default). Choose End-user if you sign in with the SmartClient or SmartESS mobile app; those accounts authenticate against ios.shinemonitor.com and otherwise fail with 'user not found'."
         }
       },
       "local": {

--- a/custom_components/dessmonitor/strings.json
+++ b/custom_components/dessmonitor/strings.json
@@ -35,14 +35,14 @@
           "password": "Password",
           "company_key": "Company Key (leave default unless specified by your installer)",
           "update_interval": "Update interval (seconds)",
-          "account_mode": "Account type"
+          "api_profile": "Platform"
         },
         "data_description": {
           "username": "Your DessMonitor account username",
           "password": "Your DessMonitor account password",
           "company_key": "Your company/vendor key (default: {default_company_key})",
           "update_interval": "How often to fetch data from DessMonitor. Default is 300 seconds (5 minutes).",
-          "account_mode": "Distributor/installer accounts use authSource against api.dessmonitor.com (default). Choose End-user if you sign in with the SmartClient or SmartESS mobile app; those accounts authenticate against ios.shinemonitor.com and otherwise fail with 'user not found'."
+          "api_profile": "Which Eybond platform hosts the account. DessMonitor / SmartESS is energy storage (source=1, api.dessmonitor.com) and is the default. ShineMonitor / SmartClient for Solar is photovoltaic (source=0, ios.shinemonitor.com). Choosing the wrong one fails with 'user not found'."
         }
       },
       "local": {

--- a/custom_components/dessmonitor/translations/en.json
+++ b/custom_components/dessmonitor/translations/en.json
@@ -34,13 +34,15 @@
           "username": "Username",
           "password": "Password",
           "company_key": "Company Key (leave default unless specified by your installer)",
-          "update_interval": "Update interval (seconds)"
+          "update_interval": "Update interval (seconds)",
+          "api_profile": "Platform"
         },
         "data_description": {
           "username": "Your DessMonitor account username",
           "password": "Your DessMonitor account password",
           "company_key": "Your company/vendor key (default: {default_company_key})",
-          "update_interval": "How often to fetch data from DessMonitor. Default is 300 seconds (5 minutes)."
+          "update_interval": "How often to fetch data from DessMonitor. Default is 300 seconds (5 minutes).",
+          "api_profile": "Which Eybond platform hosts the account. DessMonitor / SmartESS is energy storage (source=1, api.dessmonitor.com) and is the default. ShineMonitor / SmartClient for Solar is photovoltaic (source=0, ios.shinemonitor.com). Choosing the wrong one fails with 'user not found'."
         }
       },
       "local": {

--- a/tests/fixtures/devcode_518_query_device_last_data.json
+++ b/tests/fixtures/devcode_518_query_device_last_data.json
@@ -1,0 +1,32 @@
+{
+  "_comment": [
+    "Sanitized queryDeviceLastData response from a live devcode 518 grid-tie",
+    "PV inverter (BRAZIL-H grid profile), captured for PR #31. Account, plant,",
+    "collector and serial identifiers are placeholders; the field titles and",
+    "units are verbatim, because they are the whole point of the fixture."
+  ],
+  "err": 0,
+  "desc": "ERR_NONE",
+  "dat": {
+    "pn": "REDACTED-PN",
+    "devcode": 518,
+    "devaddr": 1,
+    "sn": "REDACTED-SN",
+    "gts": "2026-08-30 13:40:12",
+    "title": [
+      {"title": "active power", "unit": "W", "val": "1834"},
+      {"title": "DC output power", "unit": "W", "val": "1902"},
+      {"title": "total energy", "unit": "kWh", "val": "10468.9"},
+      {"title": "today energy", "unit": "kWh", "val": "12.7"},
+      {"title": "current year generating capacity", "unit": "kWh", "val": "4021.5"},
+      {"title": "grid frequency", "unit": "Hz", "val": "59.98"},
+      {"title": "inverter temperature", "unit": "°C", "val": "41.3"},
+      {"title": "DC voltage 1", "unit": "V", "val": "312.4"},
+      {"title": "DC current 1", "unit": "A", "val": "3.11"},
+      {"title": "DC voltage 2", "unit": "V", "val": "308.7"},
+      {"title": "DC current 2", "unit": "A", "val": "3.04"},
+      {"title": "apparent power value", "unit": "VA", "val": "1871"},
+      {"title": "grid voltage", "unit": "V", "val": "223.6"}
+    ]
+  }
+}

--- a/tests/test_api_profiles.py
+++ b/tests/test_api_profiles.py
@@ -1,0 +1,253 @@
+"""API profile behaviour: identity, transport encoding and token isolation.
+
+These cover the review points on PR #31: that each profile authenticates with
+its own host/action/source, that the string we sign is byte-for-byte the string
+aiohttp transmits, and that a cached token never crosses profiles.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yarl
+
+from custom_components.dessmonitor.api import DessMonitorAPI
+from custom_components.dessmonitor.const import (
+    API_PROFILE_DESSMONITOR_ESS,
+    API_PROFILE_SHINEMONITOR_SOLAR,
+    API_PROFILES,
+    DEFAULT_API_PROFILE,
+    resolve_api_profile,
+)
+
+
+class _CapturingSession:
+    """Minimal aiohttp stand-in that records what would go on the wire."""
+
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        self.requested: list[Any] = []
+        self._payload = payload or {"err": 0, "dat": {}}
+
+    def get(self, url: Any, **_: Any) -> Any:
+        self.requested.append(url)
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json = AsyncMock(return_value=self._payload)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=response)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return ctx
+
+    @property
+    def last_url(self) -> str:
+        return str(self.requested[-1])
+
+
+def _sha1(value: str) -> str:
+    return hashlib.sha1(value.encode()).hexdigest().lower()
+
+
+# --- profiles ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("profile", "host", "action", "source"),
+    [
+        (
+            API_PROFILE_DESSMONITOR_ESS,
+            "api.dessmonitor.com",
+            "authSource",
+            "1",
+        ),
+        (
+            API_PROFILE_SHINEMONITOR_SOLAR,
+            "ios.shinemonitor.com",
+            "auth",
+            "0",
+        ),
+    ],
+)
+async def test_each_profile_authenticates_against_its_own_backend(
+    profile: str, host: str, action: str, source: str
+) -> None:
+    """Host, auth action and source travel together, per profile."""
+    session = _CapturingSession(
+        {"err": 0, "dat": {"token": "t", "secret": "s", "expire": 3600}}
+    )
+    api = DessMonitorAPI("user", "pw", session=session, api_profile=profile)
+
+    await api.authenticate()
+
+    url = session.last_url
+    assert host in url
+    assert f"&action={action}&" in url
+    assert f"&source={source}" in url
+
+
+def test_no_profile_impersonates_a_third_party_application() -> None:
+    """The integration identifies as itself.
+
+    ios.shinemonitor.com accepts action=auth&source=0 with our own _app_id_ --
+    verified against a live account -- so there is no reason to send the mobile
+    app's bundle id.
+    """
+    for profile in API_PROFILES.values():
+        assert profile["app_id"] == "ha-dessmonitor"
+
+
+def test_default_profile_is_the_pre_existing_behaviour() -> None:
+    """An entry that predates the selector must not change backend."""
+    assert DEFAULT_API_PROFILE == API_PROFILE_DESSMONITOR_ESS
+    assert API_PROFILES[DEFAULT_API_PROFILE]["auth_action"] == "authSource"
+    assert resolve_api_profile({}) == DEFAULT_API_PROFILE
+
+
+def test_legacy_account_mode_key_still_resolves() -> None:
+    """Entries created by the earlier revision of this branch keep working."""
+    assert resolve_api_profile({"account_mode": "end_user"}) == (
+        API_PROFILE_SHINEMONITOR_SOLAR
+    )
+    assert resolve_api_profile({"account_mode": "distributor"}) == (
+        API_PROFILE_DESSMONITOR_ESS
+    )
+    # an explicit new-style value always wins
+    assert (
+        resolve_api_profile(
+            {"api_profile": API_PROFILE_DESSMONITOR_ESS, "account_mode": "end_user"}
+        )
+        == API_PROFILE_DESSMONITOR_ESS
+    )
+
+
+# --- transport encoding (review point 5) ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "username",
+    ["Fabio Trentini", "a+b", "a&b", "José", "a/b", "a?b", "a b/c?d+e"],
+)
+async def test_signature_matches_the_bytes_actually_transmitted(
+    username: str,
+) -> None:
+    """The signed action string must survive yarl untouched.
+
+    quote_plus and yarl's requoting agree on most characters but diverge on "/"
+    and "?", where yarl turns %2F and %3F back into the bare character. Signing
+    one string and sending another is rejected as ERR_PASSWORD_VERIF_FAIL, so
+    this recomputes the signature from the URL that reaches the session.
+    """
+    session = _CapturingSession(
+        {"err": 0, "dat": {"token": "t", "secret": "s", "expire": 3600}}
+    )
+    api = DessMonitorAPI(
+        username, "pw", session=session, api_profile=API_PROFILE_SHINEMONITOR_SOLAR
+    )
+
+    await api.authenticate()
+
+    sent = session.requested[-1]
+    assert isinstance(sent, yarl.URL), "URL must be pre-encoded for aiohttp"
+    # yarl must not have rewritten anything on its way out
+    assert str(sent) == str(yarl.URL(str(sent), encoded=True))
+
+    raw = str(sent)
+    query = raw.split("?", 1)[1]
+    parts = query.split("&")
+    sign = next(p.split("=", 1)[1] for p in parts if p.startswith("sign="))
+    salt = next(p.split("=", 1)[1] for p in parts if p.startswith("salt="))
+    action_string = "&" + "&".join(
+        p for p in parts if not p.startswith(("sign=", "salt="))
+    )
+
+    expected = _sha1(f"{salt}{_sha1('pw')}{action_string}")
+    assert sign == expected
+
+
+# --- token isolation (review point 7) ---------------------------------------
+
+
+async def test_cached_token_from_another_profile_is_discarded() -> None:
+    """A token is only valid on the host that issued it."""
+    store = MagicMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "token": "t",
+            "secret": "s",
+            "token_expire": 2**31,
+            "api_profile": API_PROFILE_DESSMONITOR_ESS,
+        }
+    )
+    store.async_save = AsyncMock()
+    store.async_remove = AsyncMock()
+    api = DessMonitorAPI(
+        "user",
+        "pw",
+        session=MagicMock(),
+        store=store,
+        api_profile=API_PROFILE_SHINEMONITOR_SOLAR,
+    )
+
+    assert await api.load_saved_token() is False
+    assert api.token is None
+
+
+async def test_cached_token_from_the_same_profile_is_used() -> None:
+    """The isolation must not throw away a perfectly good token."""
+    store = MagicMock()
+    store.async_load = AsyncMock(
+        return_value={
+            "token": "t",
+            "secret": "s",
+            "token_expire": 2**31,
+            "api_profile": API_PROFILE_SHINEMONITOR_SOLAR,
+        }
+    )
+    store.async_save = AsyncMock()
+    api = DessMonitorAPI(
+        "user",
+        "pw",
+        session=MagicMock(),
+        store=store,
+        api_profile=API_PROFILE_SHINEMONITOR_SOLAR,
+    )
+
+    assert await api.load_saved_token() is True
+    assert api.token == "t"
+
+
+async def test_token_cached_before_this_field_existed_belongs_to_the_default() -> None:
+    """No profile recorded means it was written by the pre-profile code."""
+    store = MagicMock()
+    store.async_load = AsyncMock(
+        return_value={"token": "t", "secret": "s", "token_expire": 2**31}
+    )
+    store.async_save = AsyncMock()
+    api = DessMonitorAPI(
+        "user", "pw", session=MagicMock(), store=store, api_profile=DEFAULT_API_PROFILE
+    )
+
+    assert await api.load_saved_token() is True
+
+
+async def test_saved_token_records_its_profile() -> None:
+    """Otherwise the check above has nothing to compare against."""
+    store = MagicMock()
+    store.async_save = AsyncMock()
+    session = _CapturingSession(
+        {"err": 0, "dat": {"token": "t", "secret": "s", "expire": 3600}}
+    )
+    api = DessMonitorAPI(
+        "user",
+        "pw",
+        session=session,
+        store=store,
+        api_profile=API_PROFILE_SHINEMONITOR_SOLAR,
+    )
+
+    await api.authenticate()
+
+    saved = store.async_save.await_args.args[0]
+    assert saved["api_profile"] == API_PROFILE_SHINEMONITOR_SOLAR

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -572,3 +572,87 @@ async def test_hybrid_validation_preserves_entered_collector_list(
     )
     assert defaults[CONF_LOCAL_POLL_INTERVAL] == "10"
     assert defaults[CONF_LOCAL_REDIRECT_CONFIRMED] is False
+
+
+@pytest.mark.usefixtures("mock_validate_input", "mock_setup_entry")
+async def test_cloud_flow_stores_the_selected_api_profile(
+    hass: HomeAssistant,
+) -> None:
+    """Choosing the solar platform must survive into the entry data."""
+    from custom_components.dessmonitor.const import (
+        API_PROFILE_SHINEMONITOR_SOLAR,
+        CONF_API_PROFILE,
+    )
+
+    result = await _start_cloud_flow(hass)
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**BASE_INPUT, CONF_API_PROFILE: API_PROFILE_SHINEMONITOR_SOLAR},
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_API_PROFILE] == API_PROFILE_SHINEMONITOR_SOLAR
+
+
+@pytest.mark.usefixtures("mock_validate_input", "mock_setup_entry")
+async def test_cloud_flow_defaults_to_the_pre_existing_platform(
+    hass: HomeAssistant,
+) -> None:
+    """Not choosing anything must reproduce the behaviour before the selector."""
+    from custom_components.dessmonitor.const import (
+        CONF_API_PROFILE,
+        DEFAULT_API_PROFILE,
+        resolve_api_profile,
+    )
+
+    result = await _start_cloud_flow(hass)
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], BASE_INPUT
+    )
+    await hass.async_block_till_done()
+
+    assert result2["data"][CONF_API_PROFILE] == DEFAULT_API_PROFILE
+    assert resolve_api_profile(result2["data"]) == DEFAULT_API_PROFILE
+
+
+@pytest.mark.usefixtures("mock_validate_input", "mock_setup_entry")
+async def test_same_username_can_exist_on_both_platforms(
+    hass: HomeAssistant,
+) -> None:
+    """The unique ID carries the profile, so the second entry is not a dupe."""
+    from custom_components.dessmonitor.const import (
+        API_PROFILE_SHINEMONITOR_SOLAR,
+        CONF_API_PROFILE,
+    )
+
+    first = await _start_cloud_flow(hass)
+    created = await hass.config_entries.flow.async_configure(
+        first["flow_id"], BASE_INPUT
+    )
+    await hass.async_block_till_done()
+    assert created["type"] is FlowResultType.CREATE_ENTRY
+
+    second = await _start_cloud_flow(hass)
+    other = await hass.config_entries.flow.async_configure(
+        second["flow_id"],
+        {**BASE_INPUT, CONF_API_PROFILE: API_PROFILE_SHINEMONITOR_SOLAR},
+    )
+    await hass.async_block_till_done()
+
+    assert other["type"] is FlowResultType.CREATE_ENTRY
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len({entry.unique_id for entry in entries}) == 2
+
+
+@pytest.mark.usefixtures("mock_validate_input", "mock_setup_entry")
+async def test_default_profile_keeps_the_bare_username_as_unique_id(
+    hass: HomeAssistant,
+) -> None:
+    """Entries created before the selector must not be orphaned by it."""
+    result = await _start_cloud_flow(hass)
+    await hass.config_entries.flow.async_configure(result["flow_id"], BASE_INPUT)
+    await hass.async_block_till_done()
+
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.unique_id == BASE_INPUT[CONF_USERNAME]

--- a/tests/test_devcode_518.py
+++ b/tests/test_devcode_518.py
@@ -1,0 +1,65 @@
+"""Devcode 518 title mapping, against a sanitized API response.
+
+Without this mapping the energy and power sensors of a grid-tie PV inverter sit
+at 0 while the data is present in the payload, because devcode 518 reports
+lower-cased, spelled-out titles that do not match the canonical sensor names.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.dessmonitor.const import SENSOR_TYPES
+from custom_components.dessmonitor.device_support.device_registry import (
+    get_device_model_name,
+    map_sensor_title,
+)
+
+FIXTURE = Path(__file__).parent / "fixtures" / "devcode_518_query_device_last_data.json"
+DEVCODE = 518
+
+
+def _titles() -> list[str]:
+    with FIXTURE.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    assert payload["dat"]["devcode"] == DEVCODE
+    return [entry["title"] for entry in payload["dat"]["title"]]
+
+
+def test_fixture_carries_no_account_identifiers() -> None:
+    """The fixture must stay safe to ship in the repository."""
+    raw = FIXTURE.read_text(encoding="utf-8")
+    assert "REDACTED" in raw
+    for leaky in ("token", "sign=", "salt=", "secret"):
+        assert leaky not in raw
+
+
+def test_the_device_is_recognised() -> None:
+    assert "518" in get_device_model_name(DEVCODE)
+
+
+def test_energy_and_power_titles_map_to_canonical_names() -> None:
+    """These four are the ones that used to read 0."""
+    assert map_sensor_title(DEVCODE, "active power") == "Output Active Power"
+    assert map_sensor_title(DEVCODE, "DC output power") == "PV Power"
+    assert map_sensor_title(DEVCODE, "total energy") == "Energy Total"
+    assert map_sensor_title(DEVCODE, "today energy") == "Energy Today"
+
+
+def test_every_mapped_title_resolves_to_a_known_sensor() -> None:
+    """A mapping that points at a name the integration does not know is dead."""
+    for title in _titles():
+        mapped = map_sensor_title(DEVCODE, title)
+        if mapped != title:
+            assert mapped in SENSOR_TYPES, f"{title!r} maps to unknown {mapped!r}"
+
+
+def test_unmapped_titles_pass_through_unchanged() -> None:
+    """ "grid voltage" is already canonical, so it must not be rewritten."""
+    assert map_sensor_title(DEVCODE, "grid voltage") == "grid voltage"
+
+
+def test_other_devcodes_are_untouched_by_this_mapping() -> None:
+    """The 518 table must not leak into devices that report the same titles."""
+    assert map_sensor_title(2376, "active power") == "active power"


### PR DESCRIPTION
## Problem

The integration only supports distributor/installer accounts, which authenticate with `action=authSource` against `api.dessmonitor.com`. Accounts created in the **SmartClient / SmartESS mobile apps** are end-user accounts on a different vhost (`ios.shinemonitor.com`) that authenticate with `action=auth` using the mobile app identity. Pointing the current flow at such an account returns `ERR_NOT_FOUND_USR`, as if the account did not exist.

I derived the end-user profile by capturing the SmartClient app's own HTTPS traffic and confirmed it end to end against my live account.

## Changes

1. **Account type in the config flow** (`account_mode`). Distributor stays the default, so existing setups are unchanged. Selecting *End-user* switches host, auth action, `source` and app identity together via a per-mode profile, applied consistently to auth and every query.

2. **Sign requests with URL-encoded values.** The signature was computed over the raw action string while aiohttp/yarl URL-encode the query before sending (space → `+`, reserved → `%XX`). The server recomputes the signature over what it receives, so any username with a space (mine is `Fabio Trentini`) produced a mismatch reported confusingly as `ERR_PASSWORD_VERIF_FAIL` even with the correct password. Now each value is `quote_plus`-encoded when building the signed string. Values without special characters are unchanged.

3. **Device support for devcode 518** (solar grid-tie inverter, Q0025-series data loggers). These report spelled-out titles (`active power`, `total energy`, `today energy`) that don't match the canonical sensor names, so power/energy sensors stayed at 0 despite the data being present. Adds the title mapping.

## Testing

Verified against a live end-user account (BRAZIL-H grid profile inverter):

- Auth, `queryPlants`, `webQueryCollectorsEs`, `queryCollectorDevices` and `queryDeviceLastData` all return `err=0` in end-user mode.
- Sensors populate correctly: Solar Power, Energy Total (8311 kWh), Energy Today, Energy Year, PV1/PV2 voltage & current, inverter temperature, grid frequency.
- Distributor mode paths are unchanged (defaults preserved; encoding change is a no-op for values without special characters).

Happy to adjust naming, split the commits differently, or rebase onto another branch if you prefer.